### PR TITLE
switch from legacy cmscloud to aldryn-snake

### DIFF
--- a/aldryn_config.py
+++ b/aldryn_config.py
@@ -31,4 +31,6 @@ class Form(forms.BaseForm):
         settings['GOOGLE_ANALYTICS_ID'] = data['google_analytics_id']
         settings['GOOGLE_ANALYTICS_USE_UNIVERSAL'] = data['use_universal_analytics']
         settings['GOOGLE_ANALYTICS_TRACK_INDIVIDUALS'] = data['track_individuals']
+
+        # aldryn-snake is configured by aldryn-django-cms
         return settings

--- a/aldryn_google_analytics/models.py
+++ b/aldryn_google_analytics/models.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
-from cmscloud.template_api import registry
+from aldryn_snake.template_api import registry
 from django.conf import settings
+
 
 GOOGLE_ANALYTICS_SCRIPT = """<script type="text/javascript">
   var _gaq = _gaq || [];

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,9 @@ setup(
     author_email='info@divio.ch',
     url='https://github.com/aldryn/aldryn-google-analytics',
     packages=['aldryn_google_analytics'],
+    install_requires=[
+        'aldryn-snake',
+    ],
     license='LICENSE.txt',
     platforms=['OS Independent'],
     classifiers=CLASSIFIERS,


### PR DESCRIPTION
cmscloud.template_api was baked into the legacy v1 and v2 baseprojects. aldryn-snake is the publicly available version.
